### PR TITLE
feat(upgrade): use spark 2.4.5 with scala 2.12

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -4,9 +4,9 @@ import scala.xml.{Comment, Elem, Node => XmlNode, NodeSeq => XmlNodeSeq}
 name := "ann4s"
 
 val versions = new {
-  val spark = "2.3.0"
+  val spark = "2.4.5"
   val rocksdb = "5.11.3"
-  val scalatest = "2.2.6"
+  val scalatest = "3.1.1"
 }
 
 libraryDependencies ++= Seq(
@@ -20,7 +20,7 @@ organization := "com.github.mskimm"
 
 isSnapshot := version.value.endsWith("-SNAPSHOT")
 
-scalaVersion := "2.11.8"
+scalaVersion := "2.12.8"
 
 sources in (Compile, doc) := Seq.empty
 

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version = 0.13.15
+sbt.version = 1.3.10

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.1.6-SNAPSHOT"
+version in ThisBuild := "0.2.0-SNAPSHOT"


### PR DESCRIPTION
The Spark ML library has breaking changes. The following URL has a clear
diff to showcase how to convert from the old 2.3 to 2.4 form:
<https://github.com/apache/spark/commit/3cb1b57809d0b4a93223669f5c10cea8fc53eff6>.

`scalatest` dep is also upgraded to support 2.12.