### PR TITLE
feat(upgrade): use spark 2.4.5 with scala 2.12

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,8 @@
 .idea
 target
 annoy-index-*
+.annoy-index-*
+annoy-spark-result/
 test.ann
 *.elapsed.log
+src/test/py/

--- a/README.md
+++ b/README.md
@@ -1,9 +1,15 @@
 [![Build Status](https://travis-ci.org/mskimm/ann4s.svg?branch=master)](https://travis-ci.org/mskimm/ann4s)
 
 # Ann4s
-A Scala Implementation of [Annoy](https://github.com/spotify/annoy) which searches nearest neighbors given query point. 
 
-Ann4s also provides [DataFrame-based API](http://spark.apache.org/docs/latest/ml-guide.html) 
+This is a fork of the original [`mskimm/ann4s`](https://github.com/mskimm/ann4s), and is based off
+tag `v0.0.6`. The rest of the `README.md` is generally similar to the original but with some details
+amended.
+
+A Scala Implementation of [Annoy](https://github.com/spotify/annoy) which searches nearest neighbors
+given query point.
+
+Ann4s also provides [DataFrame-based API](http://spark.apache.org/docs/latest/ml-guide.html)
 for [Apache Spark](https://spark.apache.org/).
 
 # Scala code example
@@ -39,6 +45,7 @@ object AnnoyExample {
 # Spark code example (with DataFrame-based API)
 
 ## Item similarity computation
+
 ```scala
 val dataset: DataFrame = ??? // your dataset
 
@@ -54,11 +61,11 @@ val result: DataFrame = annoyModel
   .transform(alsModel.itemFactors)
 
 result.show()
-```      
+```
 
 The `result.show()` shows
 
-```
+```markdown
 +---+--------+-----------+
 | id|neighbor|   distance|
 +---+--------+-----------+
@@ -71,20 +78,35 @@ The `result.show()` shows
 +---+--------+-----------+
 ```
 
- - For more information of ALS see this [link](http://spark.apache.org/docs/2.0.0/ml-collaborative-filtering.html)
- - Working example is at 'src/test/scala/ann4s/spark/AnnoySparkSpec.scala'
+- For more information of ALS see this [link](http://spark.apache.org/docs/2.0.0/ml-collaborative-filtering.html)
+- Working example is at 'src/test/scala/ann4s/spark/AnnoySparkSpec.scala'
 
-# Installation
+# Installation (not applicable for this fork version)
 
-```
+```scala
 resolvers += Resolver.bintrayRepo("mskimm", "maven")
 
 libraryDependencies += "com.github.mskimm" %% "ann4s" % "0.0.6"
 ```
- - `0.0.6` is built with Apache Spark 1.6.2
+
+- `0.0.6` is built with Apache Spark 2.4.5
+
+# Forked version installation
+
+To use this forked version in another `sbt` project, put these at the root nesting level in the
+project `build.sbt`:
+
+```scala
+lazy val root = (project in file(".")).dependsOn(ann4sLib)
+lazy val ann4sLib = RootProject(uri("git://github.com/dsaidgovsg/ann4s.git#v0.0.6_spark-2.4.5_scala-2.12"))
+```
+
+The package is not published in Maven in anyway, so this is the only possible way to "use" the
+dependency. Note that Scala 2.11 is also supported at the moment, but the primary focus is to
+support Scala 2.12.
 
 # References
- - https://github.com/spotify/annoy : native implementation with serveral bindings like Python
- - https://github.com/pishen/annoy4s : Scala wrapper using JNA
- - https://github.com/spotify/annoy-java : Java implementation
 
+- <https://github.com/spotify/annoy> : native implementation with serveral bindings like Python
+- <https://github.com/pishen/annoy4s> : Scala wrapper using JNA
+- <https://github.com/spotify/annoy-java> : Java implementation

--- a/build.sbt
+++ b/build.sbt
@@ -2,14 +2,12 @@ name := "ann4s"
 
 version := "0.1.0-SNAPSHOT"
 
-scalaVersion := "2.11.8"
-
-crossScalaVersions := Seq("2.10.6")
+scalaVersion := "2.12.8"
 
 libraryDependencies ++= Seq(
-  "org.apache.spark" %% "spark-core" % "1.6.2" % "provided",
-  "org.apache.spark" %% "spark-mllib" % "1.6.2" % "provided",
-  "org.scalatest" %% "scalatest" % "2.2.6" % "test"
+  "org.apache.spark" %% "spark-core" % "2.4.5" % "provided",
+  "org.apache.spark" %% "spark-mllib" % "2.4.5" % "provided",
+  "org.scalatest" %% "scalatest" % "3.1.1" % "test"
 )
 
 organization := "com.github.mskimm"

--- a/build.sbt
+++ b/build.sbt
@@ -1,8 +1,12 @@
 name := "ann4s"
 
-version := "0.1.0-SNAPSHOT"
+version := "0.0.6"
 
 scalaVersion := "2.12.8"
+
+// Okay to drop 2.11 if the dependencies need to upgrade in the future
+// The Scala 2.11 version support assurance is just a nice-to-have
+crossScalaVersions := Seq("2.11.12", "2.12.8")
 
 libraryDependencies ++= Seq(
   "org.apache.spark" %% "spark-core" % "2.4.5" % "provided",

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version = 0.13.8
+sbt.version = 1.3.10

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,3 +1,3 @@
 logLevel := Level.Warn
 
-addSbtPlugin("me.lessis" % "bintray-sbt" % "0.3.0")
+addSbtPlugin("org.foundweekends" % "sbt-bintray" % "0.5.6")


### PR DESCRIPTION
Changes are made to differentiate between `DataFrame` and `Dataset`.

Improve the .gitignore and allow cross-compilation to 2.11 for checking
compatibility with 2.11.

Update `README.md` with installation details.